### PR TITLE
Have tmux start using Homebrew's bash

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -8,3 +8,5 @@ set -g update-environment -r
 
 if-shell "test -e /usr/local/bin/bash" "set-option -g default-shell /usr/local/bin/bash"
 
+set-option -g default-shell "/opt/homebrew/bin/bash"
+

--- a/.tmux.conf.brew-bash-no-root
+++ b/.tmux.conf.brew-bash-no-root
@@ -8,3 +8,6 @@ set -g update-environment -r
 
 if-shell "test -e /usr/local/bin/bash" "set-option -g default-shell /usr/local/bin/bash"
 
+set-option -g default-shell "/opt/homebrew/bin/bash"
+set-option -g default-command "/opt/homebrew/bin/bash"
+


### PR DESCRIPTION
This is for when you want to use Homebrew's Bash, but you can't or can't always sudo. More details are in the PR's commit messages.